### PR TITLE
Fix to doublevadd pub CMakeList unknown args error

### DIFF
--- a/nodes/doublevadd_publisher/CMakeLists.txt
+++ b/nodes/doublevadd_publisher/CMakeLists.txt
@@ -47,7 +47,7 @@ set(node_plugins "${node_plugins}composition::DoubleVaddComponent;$<TARGET_FILE:
 
 ## Using type adaptation
 ##  only available in ROS_DISTRO="rolling" for now
-if($ENV{ROS_DISTRO} STREQUAL "rolling")
+if($ENV{ROS_DISTRO} MATCHES "rolling")
   add_library(doublevadd_component_typeadapter SHARED
   src/doublevadd_component_typeadapter.cpp src/vadd.cpp)
   target_compile_definitions(doublevadd_component_typeadapter


### PR DESCRIPTION
Signed-off-by: Andrew Brahim <dirksavage88@gmail.com>

This PR is to fix the double vadd publisher CMakeList error due to unknown args. 

Replaces STREQUAL with MATCHES. #16 